### PR TITLE
#422039 - Training | UI Component | load table fields via ui component grid

### DIFF
--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SomethingDigital\AuctionItem\Controller\Adminhtml\Index;
+
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\PageFactory;
+
+/**
+ * Custom Controller for Auction Item Grid
+ *
+ * Class Index
+ * @package SomethingDigital\ContactForm\Controller\Adminhtml\Index
+ */
+class Index implements HttpGetActionInterface
+{
+
+    /**
+     * @var PageFactory
+     */
+    protected $pageFactory;
+
+    /**
+     * @param PageFactory $pageFactory
+     */
+    public function __construct(
+        PageFactory $pageFactory
+    ) {
+        $this->pageFactory = $pageFactory;
+    }
+
+    /**
+     * @return ResultInterface
+     */
+    public function execute()
+    {
+        $resultPage = $this->pageFactory->create();
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -12,6 +12,12 @@ use Magento\Framework\View\Result\PageFactory;
  */
 class Index implements HttpGetActionInterface
 {
+    /**
+     * ACL id for resource
+     *
+     * @const string
+     */
+    const ADMIN_RESOURCE = 'SomethingDigital_AuctionItem::grid';
 
     /**
      * @var PageFactory
@@ -33,6 +39,8 @@ class Index implements HttpGetActionInterface
     public function execute()
     {
         $resultPage = $this->pageFactory->create();
+        $resultPage->setActiveMenu('SomethingDigital_AuctionItem::grid');
+        $resultPage->getConfig()->getTitle()->prepend(__('Auction Item Grid'));
         return $resultPage;
     }
 }

--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -39,7 +39,7 @@ class Index implements HttpGetActionInterface
     public function execute()
     {
         $resultPage = $this->pageFactory->create();
-        $resultPage->setActiveMenu('SomethingDigital_AuctionItem::grid');
+        $resultPage->setActiveMenu(ADMIN_RESOURCE);
         $resultPage->getConfig()->getTitle()->prepend(__('Auction Item Grid'));
         return $resultPage;
     }

--- a/Controller/Adminhtml/Index/Index.php
+++ b/Controller/Adminhtml/Index/Index.php
@@ -9,7 +9,6 @@ use Magento\Framework\View\Result\PageFactory;
  * Custom Controller for Auction Item Grid
  *
  * Class Index
- * @package SomethingDigital\ContactForm\Controller\Adminhtml\Index
  */
 class Index implements HttpGetActionInterface
 {

--- a/Controller/Adminhtml/Item/MassDelete.php
+++ b/Controller/Adminhtml/Item/MassDelete.php
@@ -20,6 +20,11 @@ use SomethingDigital\AuctionItem\Model\ResourceModel\AuctionItem\CollectionFacto
 class MassDelete extends Action implements HttpPostActionInterface
 {
     /**
+     * Authorization level
+     */
+    const ADMIN_RESOURCE = 'SomethingDigital_AuctionItem::grid';
+
+    /**
      * @var CollectionFactory
      */
     protected $collectionFactory;

--- a/Controller/Adminhtml/Item/MassDelete.php
+++ b/Controller/Adminhtml/Item/MassDelete.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SomethingDigital\AuctionItem\Controller\Adminhtml\Item;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\Redirect;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NotFoundException;
+use Magento\Ui\Component\MassAction\Filter;
+use SomethingDigital\AuctionItem\Model\AuctionItemRepository;
+use SomethingDigital\AuctionItem\Model\ResourceModel\AuctionItem\CollectionFactory;
+
+/**
+ * Custom Controller for AuctionItem MassDelete
+ *
+ * Class MassDelete
+ */
+class MassDelete extends Action implements HttpPostActionInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+
+    /**
+     * @var AuctionItemRepository
+     */
+    private $auctionItemRepository;
+
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * Constructor
+     *
+     * @param Context $context
+     * @param Filter $filter
+     * @param CollectionFactory $collectionFactory
+     * @param AuctionItemRepository $auctionItemRepository
+     */
+    public function __construct(
+        Context $context,
+        Filter $filter,
+        CollectionFactory $collectionFactory,
+        AuctionItemRepository $auctionItemRepository
+    ) {
+        $this->filter = $filter;
+        $this->collectionFactory = $collectionFactory;
+        $this->auctionItemRepository = $auctionItemRepository;
+        parent::__construct($context);
+    }
+
+    /**
+     * AuctionItem delete action
+     *
+     * @return Redirect
+     */
+    public function execute(): Redirect
+    {
+        if (!$this->getRequest()->isPost()) {
+            throw new NotFoundException(__('Page not found'));
+        }
+        $collection = $this->filter->getCollection($this->collectionFactory->create());
+        $auctionItemsDeleted = 0;
+        foreach ($collection->getItems() as $auctionItem) {
+            $this->auctionItemRepository->delete($auctionItem);
+            $auctionItemsDeleted++;
+        }
+
+        if ($auctionItemsDeleted) {
+            $this->messageManager->addSuccessMessage(
+                __('A total of %1 record(s) have been deleted.', $auctionItemsDeleted)
+            );
+        }
+        return $this->resultFactory->create(ResultFactory::TYPE_REDIRECT)->setPath('rp_auction/index/index');
+    }
+}

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="SomethingDigital_AuctionItem::grid" sortOrder="10" title="View Grid"/>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add id="SomethingDigital_AuctionItem::grid_title" title="Auction Item" translate="title" module="SomethingDigital_AuctionItem" parent="Magento_Backend::content" sortOrder="50" dependsOnModule="SomethingDigital_AuctionItem" resource="Magento_Backend::content"/>
+        <add id="SomethingDigital_AuctionItem::grid" title="Auction Item Grid" translate="title" module="SomethingDigital_AuctionItem" parent="SomethingDigital_AuctionItem::grid_title" sortOrder="10" dependsOnModule="SomethingDigital_AuctionItem" action="rp_auction/index/index" resource="Magento_Backend::content"/>
+    </menu>
+</config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-        <add id="SomethingDigital_AuctionItem::grid_title" title="Auction Item" translate="title" module="SomethingDigital_AuctionItem" parent="Magento_Backend::content" sortOrder="50" dependsOnModule="SomethingDigital_AuctionItem" resource="Magento_Backend::content"/>
-        <add id="SomethingDigital_AuctionItem::grid" title="Auction Item Grid" translate="title" module="SomethingDigital_AuctionItem" parent="SomethingDigital_AuctionItem::grid_title" sortOrder="10" dependsOnModule="SomethingDigital_AuctionItem" action="rp_auction/index/index" resource="Magento_Backend::content"/>
+        <add id="SomethingDigital_AuctionItem::grid_title" title="Auction Item" translate="title" module="SomethingDigital_AuctionItem" parent="Magento_Backend::content" sortOrder="50" dependsOnModule="SomethingDigital_AuctionItem" resource="SomethingDigital_AuctionItem::grid"/>
+        <add id="SomethingDigital_AuctionItem::grid" title="Auction Item Grid" translate="title" module="SomethingDigital_AuctionItem" parent="SomethingDigital_AuctionItem::grid_title" sortOrder="10" dependsOnModule="SomethingDigital_AuctionItem" action="rp_auction/index/index" resource="SomethingDigital_AuctionItem::grid"/>
     </menu>
 </config>

--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="rp_auction" frontName="rp_auction">
+            <module name="SomethingDigital_AuctionItem" before="Magento_Backend" />
+        </route>
+    </router>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,15 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="auction_item_grid_data_source" xsi:type="string">SomethingDigital\AuctionItem\Model\ResourceModel\AuctionItem\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
+    <virtualType name="SomethingDigital\AuctionItem\Model\ResourceModel\AuctionItem\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
+        <arguments>
+            <argument name="mainTable" xsi:type="string">rp_auction_items</argument>
+            <argument name="resourceModel" xsi:type="string">SomethingDigital\AuctionItem\Model\ResourceModel\AuctionItem</argument>
+        </arguments>
+    </virtualType>
+</config>

--- a/view/adminhtml/layout/rp_auction_index_index.xml
+++ b/view/adminhtml/layout/rp_auction_index_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="auction_item_grid_listing"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/ui_component/auction_item_grid_listing.xml
+++ b/view/adminhtml/ui_component/auction_item_grid_listing.xml
@@ -49,6 +49,20 @@
                 </argument>
             </action>
         </massaction>
+        <filters name="listing_filters">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="templates" xsi:type="array">
+                        <item name="filters" xsi:type="array">
+                            <item name="select" xsi:type="array">
+                                <item name="component" xsi:type="string">Magento_Ui/js/form/element/ui-select</item>
+                                <item name="template" xsi:type="string">ui/grid/filters/elements/ui-select</item>
+                            </item>
+                        </item>
+                    </item>
+                </item>
+            </argument>
+        </filters>
         <paging name="listing_paging"/>
     </listingToolbar>
     <columns name="spinner_columns">

--- a/view/adminhtml/ui_component/auction_item_grid_listing.xml
+++ b/view/adminhtml/ui_component/auction_item_grid_listing.xml
@@ -1,0 +1,130 @@
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">auction_item_grid_listing.auction_item_grid_data_source</item>
+            <item name="deps" xsi:type="string">auction_item_grid_listing.auction_item_grid_data_source</item>
+        </item>
+        <item name="spinner" xsi:type="string">spinner_columns</item>
+    </argument>
+    <dataSource name="nameOfDataSource">
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider</argument>
+            <argument name="name" xsi:type="string">auction_item_grid_data_source</argument>
+            <argument name="primaryFieldName" xsi:type="string">entity_id</argument>
+            <argument name="requestFieldName" xsi:type="string">entity_id</argument>
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/provider</item>
+                    <item name="update_url" xsi:type="url" path="mui/index/render"/>
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="indexField" xsi:type="string">entity_id</item>
+                    </item>
+                </item>
+            </argument>
+        </argument>
+    </dataSource>
+    <columns name="spinner_columns">
+        <selectionsColumn name="ids">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="resizeEnabled" xsi:type="boolean">false</item>
+                    <item name="resizeDefaultWidth" xsi:type="string">55</item>
+                    <item name="indexField" xsi:type="string">entity_id</item>
+                </item>
+            </argument>
+        </selectionsColumn>
+        <column name="entity_id">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">textRange</item>
+                    <item name="sorting" xsi:type="string">asc</item>
+                    <item name="label" xsi:type="string" translate="true">ID</item>
+                </item>
+            </argument>
+        </column>
+        <column name="item_name">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">true</item>
+                        </item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Item Name</item>
+                </item>
+            </argument>
+        </column>
+        <column name="item_sku">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">false</item>
+                        </item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Item Sku</item>
+                </item>
+            </argument>
+        </column>
+        <column name="item_base_auction_price">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">true</item>
+                        </item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Item Base Auction Price</item>
+                </item>
+            </argument>
+        </column>
+        <column name="item_owner_email">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">true</item>
+                        </item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Item Owner Email</item>
+                </item>
+            </argument>
+        </column>
+        <column name="created_at">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">true</item>
+                        </item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Item Owner Email</item>
+                </item>
+            </argument>
+        </column>
+        <column name="modified_at">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="editor" xsi:type="array">
+                        <item name="editorType" xsi:type="string">text</item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">true</item>
+                        </item>
+                    </item>
+                    <item name="label" xsi:type="string" translate="true">Item Owner Email</item>
+                </item>
+            </argument>
+        </column>
+    </columns>
+</listing>

--- a/view/adminhtml/ui_component/auction_item_grid_listing.xml
+++ b/view/adminhtml/ui_component/auction_item_grid_listing.xml
@@ -23,6 +23,34 @@
             </argument>
         </argument>
     </dataSource>
+    <listingToolbar name="listing_top">
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <massaction name="listing_massaction">
+            <argument name="data" xsi:type="array">
+                <item name="data" xsi:type="array">
+                    <item name="selectProvider" xsi:type="string">auction_item_grid_listing.auction_item_grid_listing.auction_item_grid_columns.ids</item>
+                    <item name="displayArea" xsi:type="string">bottom</item>
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/tree-massactions</item>
+                    <item name="indexField" xsi:type="string">entity_id</item>
+                </item>
+            </argument>
+            <action name="delete">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="type" xsi:type="string">delete</item>
+                        <item name="label" xsi:type="string" translate="true">Delete</item>
+                        <item name="url" xsi:type="url" path="rp_auction/item/massDelete"/>
+                        <item name="confirm" xsi:type="array">
+                            <item name="title" xsi:type="string" translate="true">Delete items</item>
+                            <item name="message" xsi:type="string" translate="true">Are you sure you want to delete selected items?</item>
+                        </item>
+                    </item>
+                </argument>
+            </action>
+        </massaction>
+        <paging name="listing_paging"/>
+    </listingToolbar>
     <columns name="spinner_columns">
         <selectionsColumn name="ids">
             <argument name="data" xsi:type="array">


### PR DESCRIPTION
Created Admin Route and Admin Grid matching the ui_component grid to display contents from the auction table. Added actions to mass delete and filter the table grid. 

<img width="1499" alt="Screen Shot 2021-03-12 at 12 57 41 PM" src="https://user-images.githubusercontent.com/77416194/110979419-92d57c00-8332-11eb-9ced-c5600802ec65.png">

Delete Action:

<img width="1492" alt="Screen Shot 2021-03-12 at 12 15 09 PM" src="https://user-images.githubusercontent.com/77416194/110979474-a4b71f00-8332-11eb-98bc-8ba551cad6fc.png">

